### PR TITLE
0.3.1 pre  Fixes outdated tooling and dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,8 @@ jobs:
       uses: abatilo/actions-poetry@v3
     - name: Install dependencies
       run: |
-        poetry install --all-extras --python ${{ matrix.python-version }}  # stops poetry getting too clever and finding other python installs!
+        poetry env use ${{ matrix.python-version }}  # stops poetry getting too clever and finding other python installs!
+        poetry install --all-extras 
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on:  ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on:  ${{ matrix.os }}
     steps:
     - name: checkout cassini

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,9 +15,12 @@ permissions:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    runs-on:  ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -51,7 +54,12 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   
   compat:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    runs-on:  ${{ matrix.os }}
     steps:
     - name: checkout cassini
       uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       uses: abatilo/actions-poetry@v3
     - name: Install dependencies
       run: |
-        poetry install --all-extras
+        poetry install --all-extras --python ${{ matrix.python-version }}  # stops poetry getting too clever and finding other python installs!
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,9 @@ jobs:
         python-version: "3.10"
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
+    - name: Install dependencies
+      run: |
+        poetry install --all-extras
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
     - name: Install dependencies

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       uses: abatilo/actions-poetry@v3
     - name: Install dependencies
       run: |
-        poetry install --all-extras --python
+        poetry install --all-extras
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,11 +26,6 @@ jobs:
         python-version: "3.10"
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        curl -sSL https://install.python-poetry.org | python3 -
-        poetry install --all-extras
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -57,14 +52,12 @@ jobs:
     steps:
     - name: checkout cassini
       uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
-    - name: setup pip/ poetry
-      run: |
-        python -m pip install --upgrade pip
-        curl -sSL https://install.python-poetry.org | python3 -
+        python-version: "3.10"
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v3
     - name: get jupyter_cassini version
       run: |
         poetry version -s

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on:  ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
     - name: Install dependencies
@@ -57,16 +57,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on:  ${{ matrix.os }}
     steps:
     - name: checkout cassini
       uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
     - name: get jupyter_cassini version

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.8"
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v3
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on:  ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on:  ${{ matrix.os }}
     steps:
     - name: checkout cassini

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       uses: abatilo/actions-poetry@v3
     - name: Install dependencies
       run: |
-        poetry install --all-extras
+        poetry install --all-extras --python
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on:  ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on:  ${{ matrix.os }}
     steps:
     - name: checkout cassini

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -55,10 +55,10 @@ jobs:
     steps:
     - name: checkout cassini
       uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: setup pip/ poetry
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,14 +29,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
-      - name: Setup Page Builder
-        run: |
-          python -m pip install --upgrade pip
-          curl -sSL https://install.python-poetry.org | python3 -
+          python-version: "3.9"
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
       - name: Checkout Main
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -34,8 +34,7 @@ jobs:
           exit 1
         fi
 
-        if [[ $THIS_VERSION =~ "a"]]; then
+        if [[ $THIS_VERSION =~ a ]] ; then
           echo "looks like an alpha version number, this should not be merged into a release branch"
           exit 1
         fi
-

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -33,3 +33,9 @@ jobs:
           echo "Versions match but internal changes have been made, bump required"
           exit 1
         fi
+
+        if [[ $THIS_VERSION =~ "a"]]; then
+          echo "looks like an alpha version number, this should not be merged into a release branch"
+          exit 1
+        fi
+

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.9"
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v3
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        curl -sSL https://install.python-poetry.org | python3 -
         poetry install --all-extras
     - name: check tag and release version match
       shell: bash
@@ -62,11 +62,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        curl -sSL https://install.python-poetry.org | python3 -
         poetry install --all-extras
     - name: Build package
       run: poetry build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create a `cas_project.py`:
 
 And launch it:
 
-    > python project.py
+    > python cas_project.py
 
 Head to [Quickstart](https://0hughman0.github.io/Cassini/0.3.x/) for more info.
 

--- a/cassini/ext/ipygui/extension.py
+++ b/cassini/ext/ipygui/extension.py
@@ -5,8 +5,9 @@ from .gui import GUIS
 from .components import BaseTierGui
 
 
-warnings.deprecated(
-    "Use of the ipy GUI is deprecrated, please use the JL GUI instead. This GUI will be removed in the next minor version"
+warnings.warn(
+    "Use of the ipy GUI is deprecrated, please use the JL GUI instead. This GUI will be removed in the next minor version",
+    DeprecationWarning
 )
 
 

--- a/cassini/ext/ipygui/extension.py
+++ b/cassini/ext/ipygui/extension.py
@@ -7,7 +7,7 @@ from .components import BaseTierGui
 
 warnings.warn(
     "Use of the ipy GUI is deprecrated, please use the JL GUI instead. This GUI will be removed in the next minor version",
-    DeprecationWarning
+    DeprecationWarning,
 )
 
 

--- a/cassini/ext/ipygui/extension.py
+++ b/cassini/ext/ipygui/extension.py
@@ -1,7 +1,13 @@
+import warnings
 from typing import TYPE_CHECKING
 
 from .gui import GUIS
 from .components import BaseTierGui
+
+
+warnings.deprecated(
+    "Use of the ipy GUI is deprecrated, please use the JL GUI instead. This GUI will be removed in the next minor version"
+)
 
 
 if TYPE_CHECKING:

--- a/cassini/meta.py
+++ b/cassini/meta.py
@@ -540,13 +540,19 @@ class MetaAttr(Generic[AttrType, JSONType]):
         if self.cas_field:
             return self.name, (
                 self.json_type,
-                Field(
-                    default=self.default,
-                    json_schema_extra={"x-cas-field": self.cas_field},
+                cast(
+                    FieldInfo,
+                    Field(
+                        default=self.default,
+                        json_schema_extra={"x-cas-field": self.cas_field},
+                    ),
                 ),
             )
         else:
-            return self.name, (self.json_type, Field(default=self.default))
+            return self.name, (
+                self.json_type,
+                cast(FieldInfo, Field(default=self.default)),
+            )
 
 
 T = TypeVar("T")

--- a/doc_src/docs/contributing/cassini.md
+++ b/doc_src/docs/contributing/cassini.md
@@ -14,7 +14,7 @@ Then head into the directory:
 
 Let poetry install the project dependencies and set up a virtual environment:
 
-    poetry install --with dev
+    poetry install --with dev --all-extras
 
 You can then run the test suite with:
 

--- a/doc_src/docs/contributing/jupyter_cassini.md
+++ b/doc_src/docs/contributing/jupyter_cassini.md
@@ -18,11 +18,15 @@ Dependencies and code isolation in jupyter_cassini are handled by [conda](https:
 
 To get started, create a new conda environment:
 
-    conda create -n jupyter_cassini python=3.8
+    conda create -n jupyter_cassini python=3.9
 
 Activate it!:
 
     conda activate jupyter_cassini
+
+You will likely need to install nodejs, which you can do with conda:
+
+    conda install nodejs
 
 Install ``jupyter_cassini_server`` in editable mode (this allows any changes to the server extension to be applied without reinstalling the extension):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-only"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8.1,<3.13.0"
+python = "^3.9,<3.13.0"
 ipywidgets = "^8.0"
 jupyterlab = "^4.0.0"
 typing-extensions = "^4.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0-only"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8.1,<3.12.0"
+python = "^3.8.1,<3.13.0"
 ipywidgets = "^8.0"
 jupyterlab = "^4.0.0"
 typing-extensions = "^4.7.1"
 jupyter_cassini_server = "~0.3.0"
 pydantic = "^2.8.2"
-pandas = { version="^1.0", optional=true }
+pandas = { version="^1.0", python="<3.12", optional=true }
 semantic-version = { version="^2.10.0", optional=true }
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-only"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.8.1,<3.12.0"
 ipywidgets = "^8.0"
 jupyterlab = "^4.0.0"
 typing-extensions = "^4.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cassini"
-version = "0.3.1a0"
+version = "0.3.1"
 description = "A tool to structure experimental work, data and analysis using Jupyter Lab."
 authors = ["0Hughman0 <rammers2@hotmail.co.uk>"]
 license = "GPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cassini"
-version = "0.3.0"
+version = "0.3.1a0"
 description = "A tool to structure experimental work, data and analysis using Jupyter Lab."
 authors = ["0Hughman0 <rammers2@hotmail.co.uk>"]
 license = "GPL-3.0-only"

--- a/tests/test_jlgui.py
+++ b/tests/test_jlgui.py
@@ -43,7 +43,7 @@ def test_gui_header(monkeypatch):
     monkeypatch.setattr(cassini.jlgui, 'publish_display_data', mock)
     gui = JLGui(None)
     gui.header()
-    assert mock.called_with({"application/cassini.header+json": {}})
+    assert mock.call_args.args == ({"application/cassini.header+json": {}},)
 
 
 def test_meta_editor_single_key(monkeypatch):

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -286,7 +286,7 @@ def test_meta_wrapping(get_Project, tmp_path):
     assert tier.meta['started'] == now
 
 
-def test_making_share(get_Project, tmp_path):
+def test_making_share(get_Project, tmp_path, monkeypatch):
     Project = get_Project
     project = Project(DEFAULT_TIERS, tmp_path)
     shared_project = ShareableProject(location=tmp_path / 'shared')
@@ -305,6 +305,8 @@ def test_making_share(get_Project, tmp_path):
 
     stier / 'data.txt'
     child = stier['1']
+    
+    monkeypatch.chdir(tier.folder)  # Required because href assumes cwd is same as directory notebook open in
     child_href = child.href
 
     shared_project.make_shared()


### PR DESCRIPTION
Pandas and numpy are causing us some grief.

For the IPyGUI I've been quite committed to Pandas v1.

But this update deprecates it as it causes chaos. It's only compatible up to Python 3.11.

Pandas v1 meant we were locked into numpy v1, which is only compatible up to Python 3.12.

...

Let's just deprecate the IPyGUI in this release and then remove Pandas and Numpy altogether.